### PR TITLE
cleanup: remove commented code and add attribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,6 @@ members = [
     "contracts/router",
     "contracts/tokenomics/*",
     "contracts/periphery/*"
-    #   "contracts/pair_astro_converter",
-    #   "contracts/pair_transmuter",
-    #   "contracts/pair_concentrated_duality",
-    #  "contracts/pair_concentrated_inj", TODO: rewrite OB liquidity deployment
-    #   "contracts/pair_xastro",
-    #   "contracts/pair_xyk_sale_tax",
-    #   "contracts/whitelist",
-    #   "contracts/tokenomics/*",
 ]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -57,3 +57,8 @@ Deployed contract addresses and deployment information can be found in the [Oros
 ## Docs
 
 Docs can be generated using `cargo doc --no-deps`
+
+## Attribution
+
+Forked from Astroport ([https://github.com/astroport-fi/astroport-core](https://github.com/astroport-fi/astroport-core))
+Modified by OroSwap Team - [https://github.com/oroswap/oroswap-core](https://github.com/oroswap/oroswap-core)

--- a/scripts/build_cw20.sh
+++ b/scripts/build_cw20.sh
@@ -12,9 +12,14 @@ echo "   Output dir: $OUTPUT_DIR"
 
 # ── 1) Clone and build CW20 ───────────────────────────────────────────────
 CW20_DIR="/tmp/cw20-build"
+CW20_VERSION="v2.0.0"  # Pin to latest stable version for reproducible builds
+
 if [[ ! -d "$CW20_DIR" ]]; then
-  echo "📦 Cloning CW20 repository..."
+  echo "📦 Cloning CW20 repository (version: $CW20_VERSION)..."
   git clone https://github.com/CosmWasm/cw-plus.git "$CW20_DIR"
+  cd "$CW20_DIR"
+  git checkout "$CW20_VERSION"
+  cd - > /dev/null
 fi
 
 cd "$CW20_DIR"


### PR DESCRIPTION
- Remove commented code from Cargo.toml for cleaner workspace config
- Add attribution section to README.md crediting Astroport as original source
- Update build_cw20.sh to use CW20 v2.0.0 for reproducible builds